### PR TITLE
Uhd

### DIFF
--- a/files/nodm-uzblmonitor.default
+++ b/files/nodm-uzblmonitor.default
@@ -13,7 +13,7 @@ NODM_FIRST_VT=7
 NODM_XSESSION=/etc/X11/Xsession
 
 # Options for the X server
-NODM_X_OPTIONS='-nolisten tcp -nocursor'
+NODM_X_OPTIONS='-nolisten tcp'
 
 # If an X session will run for less than this time in seconds, nodm will wait an
 # increasing bit of time before restarting the session.

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -214,8 +214,12 @@ def parse_userscript_metadata(f):
 
 
 def insert_basic_auth(url, filename="/etc/uzblmonitor-auth.json"):
-    with open(filename) as f:
-        auth_dict = json.load(f)
+    try:
+        with open(filename) as f:
+            auth_dict = json.load(f)
+    except IOError as e:
+        log.warning("Caught %s when trying to look up basic auth credentials from %s -- ignoring" % (e, filename))
+        return url
 
     parsed = list(urlparse.urlsplit(url))
     hostname = parsed[1]

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -246,7 +246,8 @@ def set_up_signal_handlers(browser):
 def parse_layout(views, state, x, y, width, height, broadcast=None):
 
     if broadcast:
-        views.append(ViewAdapter(state={'mode': 'terminal', 'value': 'DISPLAY=:0 textscroll \'{0}\''.format(broadcast)}, x=0, y=0, width=width, height=BROADCAST_HEIGHT))
+        safe_broadcast = shellquote(broadcast)
+        views.append(ViewAdapter(state={'mode': 'terminal', 'value': 'DISPLAY=:0 textscroll {0}'.format(safe_broadcast)}, x=0, y=0, width=width, height=BROADCAST_HEIGHT))
 
     if state['mode'] == 'horizontal':
         x_offset = int(float(state['value'])*width)
@@ -259,11 +260,13 @@ def parse_layout(views, state, x, y, width, height, broadcast=None):
     else:
         views.append(ViewAdapter(state, x, y, width, height))
 
-
 def get_emergency_broadcast(broadcast_file='/etc/uzblmonitor-broadcast.json'):
     with open(broadcast_file) as f:
         broadcast = f.read().strip()
     return broadcast
+
+def shellquote(s):
+    return "'" + s.replace("'", "'\\''") + "'"
 
 
 def main():

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -212,21 +212,24 @@ class Chrome(Browser):
         )
 
     def load_userscripts(self, config, tempdir):
-        target_dir = os.path.join(tempdir, "userscripts")
-        os.mkdir(target_dir)
+        extension_dir = os.path.join(tempdir, "userscripts")
+        os.mkdir(extension_dir)
         try:
             script_source = config.get('uzblmonitor', 'user_scripts')
         except ConfigParser.NoOptionError:
             return []
 
-        retval = []
+        manifest_data = {
+            "manifest_version": 2,
+            "name": ("uzblmonitor user scripts"),
+            "content_scripts": [],
+            "version": "1",
+        }
+
         for filename in os.listdir(script_source):
             source_path = os.path.join(script_source, filename)
             if os.path.isfile(source_path) and filename.endswith(".user.js"):
-                extension_dir = os.path.join(target_dir, filename[:-8])
-                retval.append("--load-extension=%s" % extension_dir)
-                os.mkdir(extension_dir)
-                userscript_path = os.path.join(extension_dir, "script.js")
+                userscript_path = os.path.join(extension_dir, filename)
                 shutil.copyfile(
                     src=source_path,
                     dst=userscript_path,
@@ -234,25 +237,19 @@ class Chrome(Browser):
 
                 with open(userscript_path) as userscript:
                     metadata = parse_userscript_metadata(userscript)
+                manifest_data['content_scripts'].append({
+                    "exclude_globs": [],
+                    "exclude_matches": [],
+                    "include_globs": metadata['include'],
+                    "js": [filename],
+                    "matches": ["http://*/*", "https://*/*"],
+                    "run_at": "document_idle"
+                })
 
-                with open(os.path.join(extension_dir, "manifest.json"), 'w') as manifest:
-                    manifest_data = {
-                        "manifest_version": 2,
-                        "name": ("converted from %s" % filename),
-                        "content_scripts": [{
-                            "exclude_globs": [],
-                            "exclude_matches": [],
-                            "include_globs": metadata['include'],
-                            "js": ["script.js"],
-                            "matches": ["http://*/*", "https://*/*"],
-                            "run_at": "document_idle"
-                        }],
-                        "version": "1",
-                    }
+        with open(os.path.join(extension_dir, "manifest.json"), 'w') as manifest:
+            json.dump(manifest_data, manifest)
 
-                    json.dump(manifest_data, manifest)
-
-        return retval
+        return ["--load-extension=%s" % extension_dir]
 
 
 def parse_userscript_metadata(f):

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -51,15 +51,15 @@ class ViewAdapter(object):
     def start(self, display):
         return Exception("Your provider should implement this")
 
-    def render(self):
-        display = random.randint(1, 1000)
+    def render(self, display):
+	if display != 0:
+            cmd = ['Xnest', ':%d' % display, '-s', '0,', '-retro', '-geometry',
+                       self.geometry_string]
+            Popen(cmd, env=dict(os.environ, DISPLAY=":0"))
 
-        cmd = ['Xnest', ':%d' % display, '-s', '0,', '-retro', '-geometry',
-                   self.geometry_string]
-        Popen(cmd, env=dict(os.environ, DISPLAY=":0"))
         Popen(
             ['matchbox-window-manager', '-use_titlebar', 'no'],
-            env=dict(os.environ, DISPLAY=":%s" % display)
+            env=dict(os.environ, DISPLAY=":%d" % display)
         )
 
         # Give the window manager some time to actually start
@@ -229,7 +229,6 @@ def parse_layout(views, state, x, y, width, height):
 
     if state['mode'] == 'horizontal':
         x_offset = int(float(state['value'])*width)
-        print "horiz"
         parse_layout(views, state['children'][0], x, y, x_offset, height)
         parse_layout(views, state['children'][1], x+x_offset, y, width-x_offset, height)
     elif state['mode'] == 'vertical':
@@ -253,8 +252,12 @@ def main():
     x, y, width, height = parse_geometry_string(geom_str)
 
     parse_layout(views, state, x, y, width, height)
+    display=0
     for view in views:
-        view.render()
+	# If there is no split, we don't need nested X server and can enable fullscreen GPU OpenGL support
+        if len(views) != 1:
+	    display += 11
+        view.render(display)
 
     while True:
         time.sleep(5)

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -246,7 +246,7 @@ def set_up_signal_handlers(browser):
 def parse_layout(views, state, x, y, width, height, broadcast=None):
 
     if broadcast:
-        views.append(ViewAdapter(state={'mode': 'terminal', 'value': 'DISPLAY=:0 python /nail/home/btrump/tkinter.py \'{0}\''.format(broadcast)}, x=0, y=0, width=width, height=BROADCAST_HEIGHT))
+        views.append(ViewAdapter(state={'mode': 'terminal', 'value': 'DISPLAY=:0 textscroll \'{0}\''.format(broadcast)}, x=0, y=0, width=width, height=BROADCAST_HEIGHT))
 
     if state['mode'] == 'horizontal':
         x_offset = int(float(state['value'])*width)
@@ -287,7 +287,7 @@ def main():
     display = 0
     for view in views:
         # If there is no split, we don't need nested X server and can enable fullscreen GPU OpenGL support
-        if len(views) != 1 or emergency_broadcast:
+        if len(views) != 1 or broadcast:
             display += 11
         view.render(display)
 

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -204,7 +204,7 @@ class Chrome(Browser):
 
         return (
             [
-                "/usr/bin/google-chrome",
+                "/usr/bin/google-chrome-stable",
                 "--user-data-dir=%s" % user_data_dir,
                 "--app=%s" % insert_basic_auth(url),
             ] + userscript_args,
@@ -263,7 +263,7 @@ def parse_userscript_metadata(f):
     for line in lines[1:]:
         if re.match(r"// ==/UserScript==", line):
             break
-        match = re.match(r"// @(\w+)\s+(.*)", line)
+        match = re.match(r"// @(\S+)\s+(.*)", line)
         retval.setdefault(match.group(1), []).append(match.group(2))
 
     return retval

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -5,10 +5,12 @@ import json
 import logging
 import os
 import os.path
+import random
 import re
 import shutil
 import signal
 import socket
+import subprocess
 from subprocess import Popen
 import sys
 import threading
@@ -21,21 +23,65 @@ CONFIG_FILE = "/etc/uzblmonitor.conf"
 log = logging.getLogger("uzblmonitor")
 
 
-class Browser(object):
+def geometry_string(x, y, width, height):
+    return '%dx%d+%d+%d' % (width, height, x, y)
 
-    p = None
-    sock = None
-    url = None
-    should_stop = False
 
-    def start(self):
-        log.info("Starting browser")
+class ViewAdapter(object):
+
+    def __init__(self, state, x, y, width, height):
+        self.view = None
+        self.geometry_string = geometry_string(x, y, width, height)
+
+        if state['mode'] == 'url':
+            self.view = Chrome(state['value'])
+        elif state['mode'] == 'terminal':
+            self.view = Terminal(state['value'])
+        else:
+            raise Exception("Unknown mode")
+
+    def start(self, display):
+        return Exception("Your provider should implement this")
+
+    def render(self):
+        display = random.randint(1, 1000)
+
+        cmd = ['Xnest', ':%d' % display, '-s', '0,', '-retro', '-geometry',
+                   self.geometry_string]
+        Popen(cmd, env=dict(os.environ, DISPLAY=":0"))
+        Popen(
+            ['matchbox-window-manager', '-use_titlebar', 'no'],
+            env=dict(os.environ, DISPLAY=":%s" % display)
+        ),
+        self.view.start(display)
+
+
+class Terminal():
+
+    def __init__(self, cmd):
+        self.pid = None
+        self.cmd = cmd
+
+    def start(self, display=":0"):
+        cmd = ["xterm", "-rv", "-hold", "-e", "bash", "-c", self.cmd]
+        self.pid = Popen(cmd, env=dict(os.environ, DISPLAY=":%s" % display), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+
+class Chrome():
+
+    def __init__(self, url):
+        self.url = url
+
+    def start(self, display=":0"):
+        log.info("Starting browser on display %s" % display)
 
         self.should_stop = False
 
         cmd, env = self.browser_command_env
+        print cmd
 
-        self.p = Popen(cmd, env=dict(os.environ, **env), stderr=open(os.devnull, 'w'))
+        self.p = Popen(cmd, env=dict(os.environ, DISPLAY=":%s" % display, **env), stderr=open(os.devnull, 'w'))
         log.info("Started subprocess %d", self.p.pid)
 
     def stop(self):
@@ -62,140 +108,9 @@ class Browser(object):
         self.exit()
         self.start()
 
-    def wait_for_stop(self):
-        while not self.should_stop:
-            time.sleep(1)
-
-        log.info("Received stop notification; exiting")
-        self.exit()
-
-
-class Uzbl(Browser):
-    browser_command_env = (["/usr/bin/uzbl-browser"], {})
-    socket_format = "/tmp/uzbl_socket_{0}"
-
-    def start(self):
-        super(Uzbl, self).start()
-
-        self.sock = self._wait_for_socket()
-        self.sock.settimeout(1)
-        threading.Thread(target=self._start_socket_reader).start()
-
-        self.send_initial_cmds()
-        self.reload_config()
-
-    def reload_config(self):
-        log.info("Reloading config")
-
-        if not os.path.isfile(CONFIG_FILE):
-            return
-
-        config = self.read_config()
-        url = config.get('uzblmonitor', 'url')
-
-        if not url:
-            fqdn = socket.getfqdn()
-            html = "<h1 style='font-size: 400%'>{0}</h1>".format(fqdn)
-            url = """javascript:document.write("{0}")""".format(html)
-
-        if url != self.url:
-            self.url = url
-            self.update_uzbl()
-
-    def send_cmd(self, cmd):
-        log.debug("Sending cmd: %s", cmd)
-
-        while not self.should_stop:
-            try:
-                self.sock.sendall(cmd + '\n')
-                return
-            except socket.timeout:
-                continue
-            except socket.error:
-                time.sleep(.5)
-
-    def update_uzbl(self):
-        self.send_cmd("set uri={0}".format(self.url))
-
-    def send_initial_cmds(self):
-        self.send_cmd("set show_status=0")
-        self.send_cmd("set geometry=maximized")
-
-    @property
-    def socket_filename(self):
-        return self.socket_format.format(self.p.pid)
-
-    def _wait_for_socket(self):
-        log.info("Waiting for socket connection")
-
-        while True:
-            try:
-                sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
-                sock.connect(self.socket_filename)
-                break
-            except socket.error:
-                time.sleep(.5)
-
-        log.info("Socket connected")
-
-        return sock
-
-    def _start_socket_reader(self):
-        while not self.should_stop:
-            data = None
-
-            try:
-                data = self.sock.recv(1024)
-            except socket.timeout:
-                continue
-            except socket.error:
-                time.sleep(.5)
-                continue
-
-            if data:
-                log.debug("Data from uzbl: %r", data)
-            else:
-                time.sleep(.5)
-
-
-class LuaKit(Browser):
     @property
     def browser_command_env(self):
         config = self.read_config()
-        url = config.get('uzblmonitor', 'url')
-
-        tempdir = tempfile.mkdtemp()
-        self.load_userscripts(config, tempdir)
-
-        print "tempdir %s" % tempdir
-        return (
-            ["/usr/bin/luakit", "-c", "/etc/xdg/luakit/uzblmonitor.lua", insert_basic_auth(url)],
-            {
-                "XDG_DATA_HOME": tempdir,
-            }
-        )
-
-    def load_userscripts(self, config, tempdir):
-        target_dir = os.path.join(tempdir, "luakit", "scripts")
-        os.makedirs(target_dir)
-        try:
-            script_source = config.get('uzblmonitor', 'user_scripts')
-        except ConfigParser.NoOptionError:
-            return
-        for filename in os.listdir(script_source):
-            source_path = os.path.join(script_source, filename)
-            if os.path.isfile(source_path) and filename.endswith(".user.js"):
-                shutil.copyfile(
-                    src=source_path,
-                    dst=os.path.join(target_dir, filename)
-                )
-
-
-class Chrome(Browser):
-    @property
-    def browser_command_env(self):
-        config = self.read_config()
-        url = config.get('uzblmonitor', 'url')
 
         tempdir = tempfile.mkdtemp()
         user_data_dir = os.path.join(tempdir, 'user_data')
@@ -205,8 +120,10 @@ class Chrome(Browser):
         return (
             [
                 "/usr/bin/google-chrome-stable",
+                "--no-default-browser-check",
+                "--no-first-run",
                 "--user-data-dir=%s" % user_data_dir,
-                "--app=%s" % insert_basic_auth(url),
+                "--app=%s" % insert_basic_auth(self.url),
             ] + userscript_args,
             {}
         )
@@ -297,20 +214,34 @@ def set_up_signal_handlers(browser):
     signal.signal(signal.SIGHUP, signal_reload_config)
 
 
+def parse_layout(views, state, x, y, width, height):
+
+    if state['mode'] == 'horizontal':
+        x_offset = int(float(state['value'])*width)
+        print "horiz"
+        parse_layout(views, state['children'][0], x, y, x_offset, height)
+        parse_layout(views, state['children'][1], x+x_offset, y, width-x_offset, height)
+    elif state['mode'] == 'vertical':
+        y_offset = int(float(state['value'])*height)
+        parse_layout(views, state['children'][0], x, y, width, y_offset)
+        parse_layout(views, state['children'][1], x, y+y_offset, width, height-y_offset)
+    else:
+        views.append(ViewAdapter(state, x, y, width, height))
+
+
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
-    BrowserClass = {
-        "uzbl": Uzbl,
-        "luakit": LuaKit,
-        "google-chrome-stable": Chrome,
-    }[sys.argv[1] if len(sys.argv) > 1 else "uzbl"]
+    with open('/etc/uzblmonitor_data.conf') as f:
+        state = json.loads(f.read())
 
-    browser = BrowserClass()
-    set_up_signal_handlers(browser)
-    browser.start()
-    browser.wait_for_stop()
+    views = []
+    parse_layout(views, state, 0, 0, 1920, 1080)
+    for view in views:
+        view.render()
 
+    while True:
+        pass
 
 if __name__ == '__main__':
     main()

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -136,6 +136,7 @@ class Chrome():
                 "/usr/bin/google-chrome-stable",
                 "--no-default-browser-check",
                 "--no-first-run",
+                "--autoplay-policy=no-user-gesture-required",
                 "--user-data-dir=%s" % user_data_dir,
                 "--app=%s" % insert_basic_auth(self.url),
             ] + userscript_args,

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -6,11 +6,10 @@ import os
 import signal
 import socket
 from subprocess import Popen
+import sys
 import threading
 import time
 
-UZBL_CMD = "/usr/bin/uzbl-browser"
-SOCK_FMT = "/tmp/uzbl_socket_{0}"
 CONFIG_FILE = "/etc/uzblmonitor.conf"
 
 log = logging.getLogger("uzblmonitor")
@@ -28,15 +27,8 @@ class Browser(object):
 
         self.should_stop = False
 
-        self.p = Popen([UZBL_CMD], stderr=open(os.devnull, 'w'))
+        self.p = Popen(self.browser_command, stderr=open(os.devnull, 'w'))
         log.info("Started subprocess %d", self.p.pid)
-
-        self.sock = self._wait_for_socket()
-        self.sock.settimeout(1)
-        threading.Thread(target=self._start_socket_reader).start()
-
-        self.send_initial_cmds()
-        self.reload_config()
 
     def stop(self):
         log.info("Stopping browser")
@@ -52,6 +44,16 @@ class Browser(object):
             self.sock.close()
             self.sock = None
 
+    def read_config(self):
+        config = ConfigParser.RawConfigParser()
+        config.read(CONFIG_FILE)
+        return config
+
+    def reload_config(self):
+        log.info("Reloading config")
+        self.exit()
+        self.start()
+
     def wait_for_stop(self):
         while not self.should_stop:
             time.sleep(1)
@@ -59,14 +61,28 @@ class Browser(object):
         log.info("Received stop notification; exiting")
         self.exit()
 
+
+class Uzbl(Browser):
+    browser_command = ["/usr/bin/uzbl-browser"]
+    socket_format = "/tmp/uzbl_socket_{0}"
+
+    def start(self):
+        super(Uzbl, self).start()
+
+        self.sock = self._wait_for_socket()
+        self.sock.settimeout(1)
+        threading.Thread(target=self._start_socket_reader).start()
+
+        self.send_initial_cmds()
+        self.reload_config()
+
     def reload_config(self):
         log.info("Reloading config")
 
         if not os.path.isfile(CONFIG_FILE):
             return
 
-        config = ConfigParser.RawConfigParser()
-        config.read(CONFIG_FILE)
+        config = self.read_config()
         url = config.get('uzblmonitor', 'url')
 
         if not url:
@@ -99,7 +115,7 @@ class Browser(object):
 
     @property
     def socket_filename(self):
-        return SOCK_FMT.format(self.p.pid)
+        return self.socket_format.format(self.p.pid)
 
     def _wait_for_socket(self):
         log.info("Waiting for socket connection")
@@ -134,6 +150,14 @@ class Browser(object):
                 time.sleep(.5)
 
 
+class LuaKit(Browser):
+    @property
+    def browser_command(self):
+        config = self.read_config()
+        url = config.get('uzblmonitor', 'url')
+        return ["/usr/bin/luakit", url]
+
+
 def set_up_signal_handlers(browser):
     def signal_exit(sig, _):
         log.info("Got signal %d, exiting.", sig)
@@ -153,7 +177,12 @@ def set_up_signal_handlers(browser):
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
-    browser = Browser()
+    BrowserClass = {
+        "uzbl": Uzbl,
+        "luakit": LuaKit,
+    }[sys.argv[1] if len(sys.argv) > 1 else "uzbl"]
+
+    browser = BrowserClass()
     set_up_signal_handlers(browser)
     browser.start()
     browser.wait_for_stop()

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -19,7 +19,7 @@ import urlparse
 import tempfile
 
 CONFIG_FILE = "/etc/uzblmonitor.conf"
-
+STATE_FILE = '/etc/uzblmonitor-data.json'
 log = logging.getLogger("uzblmonitor")
 
 
@@ -232,7 +232,7 @@ def parse_layout(views, state, x, y, width, height):
 def main():
     logging.basicConfig(level=logging.DEBUG)
 
-    with open('/etc/uzblmonitor_data.conf') as f:
+    with open(STATE_FILE) as f:
         state = json.loads(f.read())
 
     views = []

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -3,17 +3,14 @@
 import ConfigParser
 import json
 import logging
+import math
 import os
 import os.path
-import random
 import re
 import shutil
 import signal
-import socket
 import subprocess
 from subprocess import Popen
-import sys
-import threading
 import time
 import urlparse
 import tempfile
@@ -42,7 +39,7 @@ class ViewAdapter(object):
         self.geometry_string = geometry_string(x, y, width, height)
 
         if state['mode'] == 'url':
-            self.view = Chrome(state['value'])
+            self.view = Chrome(*(state['value'].split(' ')))  # hacky way of not having to add a new field to the UI.
         elif state['mode'] == 'terminal':
             self.view = Terminal(state['value'])
         else:
@@ -52,9 +49,8 @@ class ViewAdapter(object):
         return Exception("Your provider should implement this")
 
     def render(self, display):
-	if display != 0:
-            cmd = ['Xnest', ':%d' % display, '-s', '0,', '-retro', '-geometry',
-                       self.geometry_string]
+        if display != 0:
+            cmd = ['Xnest', ':%d' % display, '-s', '0,', '-retro', '-geometry', self.geometry_string]
             Popen(cmd, env=dict(os.environ, DISPLAY=":0"))
 
         Popen(
@@ -75,14 +71,19 @@ class Terminal():
 
     def start(self, display=":0"):
         cmd = ["xterm", "-rv", "-hold", "-e", "bash", "-c", self.cmd]
-        self.pid = Popen(cmd, env=dict(os.environ, DISPLAY=":%s" % display), stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
+        self.pid = Popen(
+            cmd,
+            env=dict(os.environ, DISPLAY=":%s" % display),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE
+        )
 
 
 class Chrome():
 
-    def __init__(self, url):
+    def __init__(self, url, zoom=1.0):
         self.url = url
+        self.zoom = zoom
 
     def start(self, display=":0"):
         log.info("Starting browser on display %s" % display)
@@ -126,6 +127,7 @@ class Chrome():
         tempdir = tempfile.mkdtemp()
         user_data_dir = os.path.join(tempdir, 'user_data')
         os.mkdir(user_data_dir)
+        self.set_zoom(user_data_dir)
         userscript_args = self.load_userscripts(config, tempdir)
 
         return (
@@ -138,6 +140,21 @@ class Chrome():
             ] + userscript_args,
             {}
         )
+
+    def set_zoom(self, user_data_dir):
+        prefs_filename = os.path.join(user_data_dir, "Default", "Preferences")
+        os.mkdir(os.path.join(user_data_dir, "Default"))
+        with open(prefs_filename, "w") as f:
+            json.dump(
+                {
+                    "partition": {
+                        "default_zoom_level": {
+                            "0": math.log(float(self.zoom)) / math.log(1.20),
+                        }
+                    }
+                },
+                f
+            )
 
     def load_userscripts(self, config, tempdir):
         extension_dir = os.path.join(tempdir, "userscripts")
@@ -252,11 +269,11 @@ def main():
     x, y, width, height = parse_geometry_string(geom_str)
 
     parse_layout(views, state, x, y, width, height)
-    display=0
+    display = 0
     for view in views:
-	# If there is no split, we don't need nested X server and can enable fullscreen GPU OpenGL support
+        # If there is no split, we don't need nested X server and can enable fullscreen GPU OpenGL support
         if len(views) != 1:
-	    display += 11
+            display += 11
         view.render(display)
 
     while True:

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -17,6 +17,7 @@ import tempfile
 
 CONFIG_FILE = "/etc/uzblmonitor.conf"
 STATE_FILE = '/etc/uzblmonitor-data.json'
+BROADCAST_HEIGHT = 100
 log = logging.getLogger("uzblmonitor")
 
 
@@ -242,7 +243,10 @@ def set_up_signal_handlers(browser):
     signal.signal(signal.SIGHUP, signal_reload_config)
 
 
-def parse_layout(views, state, x, y, width, height):
+def parse_layout(views, state, x, y, width, height, broadcast=None):
+
+    if broadcast:
+        views.append(ViewAdapter(state={'mode': 'terminal', 'value': 'DISPLAY=:0 python /nail/home/btrump/tkinter.py \'{0}\''.format(broadcast)}, x=0, y=0, width=width, height=BROADCAST_HEIGHT))
 
     if state['mode'] == 'horizontal':
         x_offset = int(float(state['value'])*width)
@@ -254,6 +258,12 @@ def parse_layout(views, state, x, y, width, height):
         parse_layout(views, state['children'][1], x, y+y_offset, width, height-y_offset)
     else:
         views.append(ViewAdapter(state, x, y, width, height))
+
+
+def get_emergency_broadcast(broadcast_file='/etc/uzblmonitor-broadcast.json'):
+    with open(broadcast_file) as f:
+        broadcast = f.read().strip()
+    return broadcast
 
 
 def main():
@@ -268,11 +278,16 @@ def main():
     (geom_str,) = [l.split(' ')[-1] for l in xwininfo_output.split('\n') if '-geometry ' in l]
     x, y, width, height = parse_geometry_string(geom_str)
 
-    parse_layout(views, state, x, y, width, height)
+    broadcast = get_emergency_broadcast()
+    if broadcast:
+        y += BROADCAST_HEIGHT
+        height -= BROADCAST_HEIGHT
+
+    parse_layout(views, state, x, y, width, height, broadcast)
     display = 0
     for view in views:
         # If there is no split, we don't need nested X server and can enable fullscreen GPU OpenGL support
-        if len(views) != 1:
+        if len(views) != 1 or emergency_broadcast:
             display += 11
         view.render(display)
 

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -244,7 +244,7 @@ def main():
         view.render()
 
     while True:
-        pass
+        time.sleep(5)
 
 if __name__ == '__main__':
     main()

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 import ConfigParser
+import json
 import logging
 import os
 import signal
@@ -9,6 +10,7 @@ from subprocess import Popen
 import sys
 import threading
 import time
+import urlparse
 
 CONFIG_FILE = "/etc/uzblmonitor.conf"
 
@@ -155,7 +157,22 @@ class LuaKit(Browser):
     def browser_command(self):
         config = self.read_config()
         url = config.get('uzblmonitor', 'url')
-        return ["/usr/bin/luakit", url]
+        return ["/usr/bin/luakit", insert_basic_auth(url)]
+
+
+def insert_basic_auth(url, filename="/etc/uzblmonitor-auth.json"):
+    with open(filename) as f:
+        auth_dict = json.load(f)
+
+    parsed = list(urlparse.urlsplit(url))
+    hostname = parsed[1]
+
+    for entry in auth_dict['entries']:
+        if hostname == entry['domain']:
+            parsed[1] = '%s:%s@%s' % (entry['username'], entry['password'], parsed[1])
+            return urlparse.urlunsplit(parsed)
+
+    return url
 
 
 def set_up_signal_handlers(browser):

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -27,6 +27,14 @@ def geometry_string(x, y, width, height):
     return '%dx%d+%d+%d' % (width, height, x, y)
 
 
+def parse_geometry_string(geom_str):
+    """Parse a geometry string and return x, y, width, height."""
+    width, rest = geom_str.split('x')
+    height, x, y = rest.split('+')
+
+    return int(x), int(y), int(width), int(height)
+
+
 class ViewAdapter(object):
 
     def __init__(self, state, x, y, width, height):
@@ -239,7 +247,12 @@ def main():
         state = json.loads(f.read())
 
     views = []
-    parse_layout(views, state, 0, 0, 1920, 1080)
+
+    xwininfo_output = subprocess.check_output(['xwininfo', '-root'])
+    (geom_str,) = [l.split(' ')[-1] for l in xwininfo_output.split('\n') if '-geometry ' in l]
+    x, y, width, height = parse_geometry_string(geom_str)
+
+    parse_layout(views, state, x, y, width, height)
     for view in views:
         view.render()
 

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -306,7 +306,7 @@ def main():
     BrowserClass = {
         "uzbl": Uzbl,
         "luakit": LuaKit,
-        "chrome": Chrome,
+        "google-chrome-stable": Chrome,
     }[sys.argv[1] if len(sys.argv) > 1 else "uzbl"]
 
     browser = BrowserClass()

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -4,6 +4,9 @@ import ConfigParser
 import json
 import logging
 import os
+import os.path
+import re
+import shutil
 import signal
 import socket
 from subprocess import Popen
@@ -11,6 +14,7 @@ import sys
 import threading
 import time
 import urlparse
+import tempfile
 
 CONFIG_FILE = "/etc/uzblmonitor.conf"
 
@@ -29,7 +33,9 @@ class Browser(object):
 
         self.should_stop = False
 
-        self.p = Popen(self.browser_command, stderr=open(os.devnull, 'w'))
+        cmd, env = self.browser_command_env
+
+        self.p = Popen(cmd, env=dict(os.environ, **env), stderr=open(os.devnull, 'w'))
         log.info("Started subprocess %d", self.p.pid)
 
     def stop(self):
@@ -47,7 +53,7 @@ class Browser(object):
             self.sock = None
 
     def read_config(self):
-        config = ConfigParser.RawConfigParser()
+        config = ConfigParser.RawConfigParser(allow_no_value=True)
         config.read(CONFIG_FILE)
         return config
 
@@ -65,7 +71,7 @@ class Browser(object):
 
 
 class Uzbl(Browser):
-    browser_command = ["/usr/bin/uzbl-browser"]
+    browser_command_env = (["/usr/bin/uzbl-browser"], {})
     socket_format = "/tmp/uzbl_socket_{0}"
 
     def start(self):
@@ -154,10 +160,113 @@ class Uzbl(Browser):
 
 class LuaKit(Browser):
     @property
-    def browser_command(self):
+    def browser_command_env(self):
         config = self.read_config()
         url = config.get('uzblmonitor', 'url')
-        return ["/usr/bin/luakit", "-c", "/etc/xdg/luakit/uzblmonitor.lua", insert_basic_auth(url)]
+
+        tempdir = tempfile.mkdtemp()
+        self.load_userscripts(config, tempdir)
+
+        print "tempdir %s" % tempdir
+        return (
+            ["/usr/bin/luakit", "-c", "/etc/xdg/luakit/uzblmonitor.lua", insert_basic_auth(url)],
+            {
+                "XDG_DATA_HOME": tempdir,
+            }
+        )
+
+    def load_userscripts(self, config, tempdir):
+        target_dir = os.path.join(tempdir, "luakit", "scripts")
+        os.makedirs(target_dir)
+        try:
+            script_source = config.get('uzblmonitor', 'user_scripts')
+        except ConfigParser.NoOptionError:
+            return
+        for filename in os.listdir(script_source):
+            source_path = os.path.join(script_source, filename)
+            if os.path.isfile(source_path) and filename.endswith(".user.js"):
+                shutil.copyfile(
+                    src=source_path,
+                    dst=os.path.join(target_dir, filename)
+                )
+
+
+class Chrome(Browser):
+    @property
+    def browser_command_env(self):
+        config = self.read_config()
+        url = config.get('uzblmonitor', 'url')
+
+        tempdir = tempfile.mkdtemp()
+        user_data_dir = os.path.join(tempdir, 'user_data')
+        os.mkdir(user_data_dir)
+        userscript_args = self.load_userscripts(config, tempdir)
+
+        return (
+            [
+                "/usr/bin/google-chrome",
+                "--user-data-dir=%s" % user_data_dir,
+                "--app=%s" % insert_basic_auth(url),
+            ] + userscript_args,
+            {}
+        )
+
+    def load_userscripts(self, config, tempdir):
+        target_dir = os.path.join(tempdir, "userscripts")
+        os.mkdir(target_dir)
+        try:
+            script_source = config.get('uzblmonitor', 'user_scripts')
+        except ConfigParser.NoOptionError:
+            return []
+
+        retval = []
+        for filename in os.listdir(script_source):
+            source_path = os.path.join(script_source, filename)
+            if os.path.isfile(source_path) and filename.endswith(".user.js"):
+                extension_dir = os.path.join(target_dir, filename[:-8])
+                retval.append("--load-extension=%s" % extension_dir)
+                os.mkdir(extension_dir)
+                userscript_path = os.path.join(extension_dir, "script.js")
+                shutil.copyfile(
+                    src=source_path,
+                    dst=userscript_path,
+                )
+
+                with open(userscript_path) as userscript:
+                    metadata = parse_userscript_metadata(userscript)
+
+                with open(os.path.join(extension_dir, "manifest.json"), 'w') as manifest:
+                    manifest_data = {
+                        "manifest_version": 2,
+                        "name": ("converted from %s" % filename),
+                        "content_scripts": [{
+                            "exclude_globs": [],
+                            "exclude_matches": [],
+                            "include_globs": metadata['include'],
+                            "js": ["script.js"],
+                            "matches": ["http://*/*", "https://*/*"],
+                            "run_at": "document_idle"
+                        }],
+                        "version": "1",
+                    }
+
+                    json.dump(manifest_data, manifest)
+
+        return retval
+
+
+def parse_userscript_metadata(f):
+    lines = f.readlines()
+    if not re.match(r"^// ==UserScript==", lines[0]):
+        raise ValueError("user script does not start with `// ==UserScript==`")
+    retval = {}
+    for line in lines[1:]:
+        if re.match(r"// ==/UserScript==", line):
+            break
+        match = re.match(r"// @(\w+)\s+(.*)", line)
+        retval.setdefault(match.group(1), []).append(match.group(2))
+
+    return retval
 
 
 def insert_basic_auth(url, filename="/etc/uzblmonitor-auth.json"):
@@ -197,6 +306,7 @@ def main():
     BrowserClass = {
         "uzbl": Uzbl,
         "luakit": LuaKit,
+        "chrome": Chrome,
     }[sys.argv[1] if len(sys.argv) > 1 else "uzbl"]
 
     browser = BrowserClass()

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -157,7 +157,7 @@ class LuaKit(Browser):
     def browser_command(self):
         config = self.read_config()
         url = config.get('uzblmonitor', 'url')
-        return ["/usr/bin/luakit", insert_basic_auth(url)]
+        return ["/usr/bin/luakit", "-c", "/etc/xdg/luakit/uzblmonitor.lua", insert_basic_auth(url)]
 
 
 def insert_basic_auth(url, filename="/etc/uzblmonitor-auth.json"):

--- a/files/uzblmonitor
+++ b/files/uzblmonitor
@@ -52,7 +52,10 @@ class ViewAdapter(object):
         Popen(
             ['matchbox-window-manager', '-use_titlebar', 'no'],
             env=dict(os.environ, DISPLAY=":%s" % display)
-        ),
+        )
+
+        # Give the window manager some time to actually start
+        time.sleep(0.1)
         self.view.start(display)
 
 

--- a/files/uzblmonitor.conf
+++ b/files/uzblmonitor.conf
@@ -6,5 +6,6 @@ start on desktop-session-start
 env DISPLAY=:0.0
 
 script
-    exec sudo -u monitor -H /usr/bin/uzblmonitor
+    source /etc/default/uzblmonitor
+    exec sudo -u monitor -H /usr/bin/uzblmonitor "$BROWSER"
 end script

--- a/files/uzblmonitor.conf
+++ b/files/uzblmonitor.conf
@@ -7,9 +7,5 @@ env DISPLAY=:0.0
 
 script
     . /etc/default/uzblmonitor
-    for output in HDMI1 HDMI2 HDMI3; do
-        xrandr --output $output --off || true
-        xrandr --output $output --auto || true
-    done
     exec sudo -u monitor -H /usr/bin/uzblmonitor "$BROWSER"
 end script

--- a/files/uzblmonitor.conf
+++ b/files/uzblmonitor.conf
@@ -7,5 +7,9 @@ env DISPLAY=:0.0
 
 script
     . /etc/default/uzblmonitor
+    for output in HDMI1 HDMI2 HDMI3; do
+        xrandr --output $output --off || true
+        xrandr --output $output --auto || true
+    done
     exec sudo -u monitor -H /usr/bin/uzblmonitor "$BROWSER"
 end script

--- a/files/uzblmonitor.conf
+++ b/files/uzblmonitor.conf
@@ -6,6 +6,6 @@ start on desktop-session-start
 env DISPLAY=:0.0
 
 script
-    source /etc/default/uzblmonitor
+    . /etc/default/uzblmonitor
     exec sudo -u monitor -H /usr/bin/uzblmonitor "$BROWSER"
 end script

--- a/files/uzblmonitor.conf
+++ b/files/uzblmonitor.conf
@@ -1,7 +1,7 @@
 description "Start uzbl yo"
 author "Patrick Lucas <me@patricklucas.com>"
 
-start on desktop-session-start
+start on screen-ready
 
 env DISPLAY=:0.0
 

--- a/files/uzblmonitor.lua
+++ b/files/uzblmonitor.lua
@@ -1,0 +1,8 @@
+require "window"
+
+window.init_funcs.blurp = function(w)
+  w.sbar.layout:hide()
+  w.sbar.hidden = true
+end
+
+require "rc"

--- a/files/xsession
+++ b/files/xsession
@@ -1,4 +1,4 @@
 #!/bin/bash
 xset -dpms
 xset s off
-exec matchbox-window-manager -use_titlebar no
+exec sleep infinity

--- a/files/xsession
+++ b/files/xsession
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-export DISPLAY=":0"
+# If you run this manually you may want to type the following line first:
+# export DISPLAY=":0"
+
 # Disable power management on the interface
 xset -dpms
 # Disable screen saver blanking
@@ -9,6 +11,8 @@ xset s off
 
 connected_port=$(xrandr --current 2>/dev/null |grep ' connected [0-9]*x[0-9]' |cut -d ' ' -f1)
 
+# Refresh the list of supported modes as sometimes they don't show up
+xrandr --output $connected_port --auto
 # If the TV supports UHD resolution, then we try to enable it
 if xrandr --current |grep -q -E '(3840x2160|4096x2160)' ; then
     # First with Sony 4k TV we need to disable this interface
@@ -16,5 +20,8 @@ if xrandr --current |grep -q -E '(3840x2160|4096x2160)' ; then
     # Then we enable it with a refresh rate of 24, which is enough for our use case
     xrandr --output $connected_port --mode 3840x2160 --rate 24
 fi
+
+#Emit a screen ready event to upstart
+/sbin/initctl -q emit screen-ready
 
 exec sleep infinity

--- a/files/xsession
+++ b/files/xsession
@@ -1,6 +1,20 @@
 #!/bin/bash
+
+export DISPLAY=":0"
+# Disable power management on the interface
 xset -dpms
+# Disable screen saver blanking
 xset s off
-# Force UHD (usually native panel resolution) instead of 4k
-xrandr --current |grep -q 'connected 4096x2160' && xrandr --output $(xrandr --current |grep 'connected 4096x2160' |cut -d ' ' -f1) --mode 3840x2160
+
+
+connected_port=$(xrandr --current 2>/dev/null |grep ' connected [0-9]*x[0-9]' |cut -d ' ' -f1)
+
+# If the TV supports UHD resolution, then we try to enable it
+if xrandr --current |grep -q -E '(3840x2160|4096x2160)' ; then
+    # First with Sony 4k TV we need to disable this interface
+    xrandr --output $connected_port --off
+    # Then we enable it with a refresh rate of 24, which is enough for our use case
+    xrandr --output $connected_port --mode 3840x2160 --rate 24
+fi
+
 exec sleep infinity

--- a/files/xsession
+++ b/files/xsession
@@ -1,4 +1,6 @@
 #!/bin/bash
 xset -dpms
 xset s off
+# Force UHD (usually native panel resolution) instead of 4k
+xrandr --current |grep -q 'connected 4096x2160' && xrandr --output $(xrandr --current |grep 'connected 4096x2160' |cut -d ' ' -f1) --mode 3840x2160
 exec sleep infinity

--- a/files/xsession
+++ b/files/xsession
@@ -22,6 +22,6 @@ if xrandr --current |grep -q -E '(3840x2160|4096x2160)' ; then
 fi
 
 #Emit a screen ready event to upstart
-/sbin/initctl -q emit screen-ready
+[ -x /sbin/initctl ] && /sbin/initctl -q emit screen-ready
 
 exec sleep infinity

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -83,7 +83,8 @@ class uzblmonitor(
     source => 'puppet:///modules/uzblmonitor/uzblmonitor',
   } ->
   file { '/etc/default/uzblmonitor':
-    content => "BROWSER=${quoted_browser}"
+    content => "BROWSER=${quoted_browser}",
+    notify => Service['uzblmonitor'],
   } ->
   file { '/etc/init/uzblmonitor.conf':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,8 @@ class uzblmonitor(
     ensure => purged,
   } ->
   # Install NoDM and Matchbox for kiosk-style display/window management
-  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager', 'xnest', 'xterm']:
+  # x11-utils for resolution detection in the python script
+  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager', 'xnest', 'xterm', 'x11-utils']:
     ensure => latest,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -75,7 +75,7 @@ class uzblmonitor(
 
   package { 'uzblmonitor_browser_package':
     name => $browser,
-    ensure => installed,
+    ensure => latest,
   } ->
   file { '/usr/bin/uzblmonitor':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,7 +24,7 @@
 #  }
 #
 class uzblmonitor(
-  $browser = 'uzbl'
+  $browser = 'google-chrome-stable'
 ) {
 
   $quoted_browser = shellquote($browser)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -45,6 +45,7 @@ class uzblmonitor(
   user { 'monitor':
     ensure     => present,
     managehome => true,
+    groups     => ['audio']
   } ->
   file { '/home/monitor/.xsession':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,7 +50,7 @@ class uzblmonitor(
   user { 'monitor':
     ensure     => present,
     managehome => true,
-    groups     => ['audio']
+    groups     => ['audio', 'video']
   } ->
   file { '/home/monitor/.xsession':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -99,4 +99,9 @@ class uzblmonitor(
     require => Service['nodm-uzblmonitor'],
   }
 
+  if $browser == 'luakit' {
+    file { '/etc/xdg/luakit/uzblmonitor.lua':
+      source => 'puppet:///modules/uzblmonitor/uzblmonitor.lua',
+    }
+  }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -23,7 +23,11 @@
 #  # ...
 #  }
 #
-class uzblmonitor {
+class uzblmonitor(
+  $browser = 'uzbl'
+) {
+
+  $quoted_browser = shellquote($browser)
 
   # Remove stock-Ubuntu DM packages
   package { ['lightdm', 'ubuntu-session', 'unity', 'unity-greeter']:
@@ -77,6 +81,9 @@ class uzblmonitor {
     group  => root,
     mode   => '0755',
     source => 'puppet:///modules/uzblmonitor/uzblmonitor',
+  } ->
+  file { '/etc/default/uzblmonitor':
+    content => "BROWSER=${quoted_browser}"
   } ->
   file { '/etc/init/uzblmonitor.conf':
     ensure => file,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -35,11 +35,11 @@ class uzblmonitor(
   } ->
   # Install NoDM and Matchbox for kiosk-style display/window management
   package { ['xserver-xorg', 'nodm', 'matchbox-window-manager']:
-    ensure => installed,
+    ensure => latest,
   }
 
   package { 'browser-plugin-gnash':
-    ensure => installed,
+    ensure => latest,
   }
 
   user { 'monitor':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class uzblmonitor(
     ensure => purged,
   } ->
   # Install NoDM and Matchbox for kiosk-style display/window management
-  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager']:
+  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager', 'xnest']:
     ensure => latest,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class uzblmonitor(
     ensure => purged,
   } ->
   # Install NoDM and Matchbox for kiosk-style display/window management
-  package { ['xserver-xorg', 'nodm', 'matchbox-window-manager']:
+  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager']:
     ensure => latest,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,7 +34,7 @@ class uzblmonitor(
     ensure => purged,
   } ->
   # Install NoDM and Matchbox for kiosk-style display/window management
-  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager', 'xnest']:
+  package { ['xserver-xorg', 'xserver-xorg-core', 'nodm', 'matchbox-window-manager', 'xnest', 'xterm']:
     ensure => latest,
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -72,7 +72,8 @@ class uzblmonitor(
     require => Package['nodm'],
   }
 
-  package { 'uzbl':
+  package { 'uzblmonitor_browser_package':
+    name => $browser,
     ensure => installed,
   } ->
   file { '/usr/bin/uzblmonitor':

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -42,6 +42,10 @@ class uzblmonitor(
     ensure => latest,
   }
 
+  package { 'unclutter':
+    ensure => latest,
+  }
+
   user { 'monitor':
     ensure     => present,
     managehome => true,


### PR DESCRIPTION
We observed different behaviour with our various mac minis connected to UHD TVs

Some of them shows support for all resolutions including UHD and 4k
They select 4k automatically but the input isn't detected by the TV
Setting it to UHD works

The Sony UHD android TV have a different behaviour
After boot, they show only support for 1920x1080 and select that one by default
However the screen remains blank again. For these turning the interface off and on does the trick
Running xrandr in --auto also refreshes the list of supported resolutions.

So here is what this script does:
1) Detect the used output
2) Refresh the supported resolutions
3a) If UHD or 4k are listed : turn interface off, turn it back on with UHD
3b) if not, do nothing
4) send an screen-ready event to upstart

uzblmonitor.conf has been updated to start on this event rather than desktop-session-start
Otherwise the window manager in uzblmonitor calculates the geometry before the final resolution is final.

This has been tested on the 2 model of Sony UHD TV that we have with 4k compatible mac minis
and on a non 4k compatible mac mini. (full test including reboot)